### PR TITLE
refactor: use 'sass' instead of 'node_sass'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/sass",
-  "version": "0.0.6",
+  "version": "0.1.0-0",
   "license": "MIT",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test.watch": "jest --watch"
   },
   "dependencies": {
-    "node-sass": "4.9.0"
+    "sass": "^1.13.4"
   },
   "devDependencies": {
     "@types/jest": "^23.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stencil/sass",
-  "version": "0.1.0-0",
+  "version": "0.1.0",
   "license": "MIT",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
-import { render } from 'node-sass';
-import { loadDiagnostic } from './diagnostics';
+// https://github.com/sass/dart-sass/issues/459
+// @ts-ignore
+import * as Sass from 'sass';
 import * as d from './declarations';
+import { loadDiagnostic } from './diagnostics';
 import * as util from './util';
 
 
@@ -27,7 +29,7 @@ export function sass(opts: d.PluginOptions = {}) {
 
       return new Promise<d.PluginTransformResults>(resolve => {
 
-        render(renderOpts, (err: any, sassResult: any) => {
+        Sass.render(renderOpts, (err: any, sassResult: any) => {
           if (err) {
             loadDiagnostic(context, err, fileName);
             results.code = `/**  sass error${err && err.message ? ': ' + err.message : ''}  **/`;


### PR DESCRIPTION
Dart-sass (or just [sass on npm](https://www.npmjs.com/package/sass)) provides a full JavaScript version of sass and will likely be updated sooner than lib-sass if [the documentation](https://sass-lang.com/dart-sass) is correct.  For people that live behind oppressive firewalls that block certain kinds of downloads, this is a lifesaver. 

I have run this version in my local stencil projects without issue, but we also use pretty slim sass functionality (mainly nesting, mixins and variables).

Just offering this as an option should you like to try it over node-sass.