### PR TITLE
upgrade(node-sass): upgrade node-sass to 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "test.watch": "jest --watch"
   },
   "dependencies": {
-    "node-sass": "4.9.3"
+    "node-sass": "4.x"
   },
   "devDependencies": {
     "@types/jest": "^23.3.2",
     "@types/node": "^8.5.1",
-    "@types/node-sass": "^3.10.32",
+    "@types/node-sass": "4.x",
     "jest": "^23.6.0",
     "np": "^3.0.4",
     "rimraf": "^2.6.2",


### PR DESCRIPTION
Upgrade node sass to work in linux environments. Getting an error where the node-sass doesn't support the linux environment with the set version. Updated the package.json for the latest 4.x version to allow for minor upgrades possible.