### PR TITLE
Fix - Add node-sass includePaths decoration

### DIFF
--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -3,6 +3,7 @@ import { Options } from 'node-sass';
 
 export interface PluginOptions extends Options {
   injectGlobalPaths?: string[];
+  includePaths?: string[];
 }
 
 export interface PluginTransformResults {


### PR DESCRIPTION
Hey,
I've added the node-sass `includePaths` property to the type decorations, in order to fix #14.
There are a lot more props to be added to the decorations: https://www.npmjs.com/package/node-sass

I will be more than happy to add them, just let me know and I will do so.

Best Orlandster