### PR TITLE
fix(): fix use of injectGlobalPaths in conjunction with indentedSyntax

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -39,7 +39,9 @@ export function getRenderOptions(opts: d.PluginOptions, sourceText: string, file
         injectGlobalPath = normalizePath(path.join(context.config.rootDir, injectGlobalPath));
       }
 
-      return `@import "${injectGlobalPath}";`;
+      const importTerminator = renderOpts.indentedSyntax ? '\n' : ';';
+
+      return `@import "${injectGlobalPath}"${importTerminator}`;
     }).join('');
 
     renderOpts.data = injectText + renderOpts.data;


### PR DESCRIPTION
Newer sass compiler versions completely disallow semicolons in .sass files, so the `@import "${injectGlobalPath}";` lines are causing a nonsensical

```
  semicolons aren't allowed in the indented syntax.
  L1:  \:host
```

error in every component's sass file in the stencil compiler output in the latest version of this package.

This changes it so the `@import` statements generated from injectGlobalPaths use newlines rather than semicolons when the config specifies indentedSyntax.