### PR TITLE
fix: error file path

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -19,8 +19,9 @@ export function loadDiagnostic(context: d.PluginCtx, sassError: SassException, f
     lines: []
   };
 
-  if (typeof filePath === 'string') {
-    diagnostic.absFilePath = filePath;
+  const errorFilePath = sassError.file !== 'stdin' ? sassError.file : filePath;
+  if (typeof errorFilePath === 'string') {
+    diagnostic.absFilePath = errorFilePath;
     diagnostic.relFilePath = formatFileName(context.config.rootDir, diagnostic.absFilePath);
 
     const errorLineNumber = sassError.line;

--- a/test/build.spec.ts
+++ b/test/build.spec.ts
@@ -26,7 +26,7 @@ describe('test build', () => {
       } as any,
       diagnostics: []
     };
-  })
+  });
 
   it('transform', async () => {
     const filePath = path.join(__dirname, 'fixtures', 'test-a.scss');
@@ -78,6 +78,21 @@ describe('test build', () => {
     expect(context.diagnostics[0].lines[2].errorCharStart).toEqual(-1);
     expect(context.diagnostics[0].lines[2].errorLength).toEqual(-1);
     expect(context.diagnostics[0].lines[2].text).toEqual('  div{color:green}');
+  });
+
+  it('transform, import, error', async () => {
+    const filePath = path.join(__dirname, 'fixtures', 'test-d.scss');
+    const sourceText = fs.readFileSync(filePath, 'utf8');
+    const s = sass();
+
+    await s.transform(sourceText, filePath, context);
+    console.log(context.diagnostics[0]);
+    expect(context.diagnostics).toHaveLength(1);
+    expect(context.diagnostics[0].level).toEqual('error');
+    expect(context.diagnostics[0].language).toEqual('scss');
+    expect(context.diagnostics[0].lineNumber).toEqual(2);
+    expect(context.diagnostics[0].columnNumber).toEqual(23);
+    expect(context.diagnostics[0].lines.length).toEqual(3);
   });
 
   it('name', async () => {

--- a/test/build.spec.ts
+++ b/test/build.spec.ts
@@ -86,7 +86,6 @@ describe('test build', () => {
     const s = sass();
 
     await s.transform(sourceText, filePath, context);
-    console.log(context.diagnostics[0]);
     expect(context.diagnostics).toHaveLength(1);
     expect(context.diagnostics[0].level).toEqual('error');
     expect(context.diagnostics[0].language).toEqual('scss');

--- a/test/fixtures/test-d.scss
+++ b/test/fixtures/test-d.scss
@@ -1,0 +1,1 @@
+@import './test-c.scss'


### PR DESCRIPTION
Fix #8.

I create a reproduce test case at [this commit](https://github.com/ionic-team/stencil-sass/commit/b920b81de38e3e8f787902cb41af4a42cad1ea47)

![Screen Shot 2020-01-10 at 11 58 39](https://user-images.githubusercontent.com/5120965/72125648-b73f6c80-33ac-11ea-8748-915785804de3.png)


I think the problem is if there is error in the imported file, then `sassError.line` is the line of error in the imported file, while filePath is the current sass file.

Please advise if you have a better way to fix it.