### PR TITLE
chore(github): create dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    # Disable rebasing for pull requests, as having several open pull requests all get simultaneously rebased gets
+    # noisy from a notification standpoint
+    rebase-strategy: "disabled"


### PR DESCRIPTION
this commit adds a dependabot configuration file for opening pull requests
for out of date requests

the idea here is that in order to keep dependencies up to date, have
Ionitron open PRs for us that we can triage and investigate on a continuous
basis.

this configuration has been copied from `@stencil/store` as of https://github.com/ionic-team/stencil-store/commit/c2a75b2d350fcf2c59458ee777fa0064459c5c3a