### PR TITLE
chore(infrastructure): add volta to the project

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,9 @@
     "preset": "ts-jest",
     "testURL": "http://localhost"
   },
-  "prettier": "@ionic/prettier-config"
+  "prettier": "@ionic/prettier-config",
+  "volta": {
+    "node": "16.15.0",
+    "npm": "8.11.0"
+  }
 }


### PR DESCRIPTION
this commit adds volta to the project. it pins node to v16, and npm to
v8. this change only affects the development versions of node/npm, and
does not affect the runtime itself for users of this library