### PR TITLE
chore(github): add ionitron bot to the repo

### DIFF
--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -1,0 +1,99 @@
+triage:
+  label: triage
+  dryRun: false
+
+closeAndLock:
+  labels:
+    - label: "ionitron: support"
+      message: >
+        Thanks for the issue! This issue appears to be a support request. We use this issue tracker exclusively for
+        bug reports and feature requests. Please use our [slack channel](https://stencil-worldwide.herokuapp.com/)
+        for questions about Stencil Sass.
+
+
+        Thank you for using Stencil Sass!
+    - label: "ionitron: missing template"
+      message: >
+        Thanks for the issue! It appears that you have not filled out the provided issue template. We use this issue
+        template in order to gather more information and further assist you. Please create a new issue and ensure the
+        template is fully filled out.
+
+
+        Thank you for using Stencil Sass!
+  close: true
+  lock: true
+  dryRun: false
+
+comment:
+  labels:
+    - label: "ionitron: needs reproduction"
+      message: >
+        Thanks for the issue! This issue has been labeled as `needs reproduction`. This label is added to issues that
+        need a code reproduction.
+
+
+        Please reproduce this issue in an Stencil starter component library and Stencil Sass. Please provide a way for
+        us to access it (GitHub repo, StackBlitz, etc). Without a reliable code reproduction, it is unlikely we will be
+        able to resolve the issue, leading to it being closed.
+
+
+        If you have already provided a code snippet and are seeing this message, it is likely that the code snippet was
+        not enough for our team to reproduce the issue.
+
+
+        For a guide on how to create a good reproduction, see our
+        [Contributing Guide](https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md).
+  dryRun: false
+
+noReply:
+  maxIssuesPerRun: 100
+  includePullRequests: false
+  label: Awaiting Reply
+  close: false
+  lock: false
+  dryRun: false
+
+noReproduction:
+  days: 14
+  maxIssuesPerRun: 100
+  label: "ionitron: needs reproduction"
+  responseLabel: triage
+  exemptProjects: true
+  exemptMilestones: true
+  message: >
+    Thanks for the issue! This issue is being closed due to the lack of a code reproduction. If this is still
+    an issue with the latest version of Stencil & Stencil Sass, please create a new issue and ensure the template is
+    fully filled out.
+
+
+    Thank you for using Stencil Sass!
+  close: true
+  lock: true
+  dryRun: false
+
+stale:
+  days: 30
+  maxIssuesPerRun: 100
+  exemptLabels:
+    - "Bug: Validated"
+    - "Feature: Want this? Upvote it!"
+    - good first issue
+    - help wanted
+    - Request For Comments
+    - "Resolution: Needs Investigation"
+    - "Resolution: Refine"
+    - triage
+  exemptAssigned: true
+  exemptProjects: true
+  exemptMilestones: true
+  label: "ionitron: stale issue"
+  message: >
+    Thanks for the issue! This issue is being closed due to inactivity. If this is still
+    an issue with the latest version of Stencil, please create a new issue and ensure the
+    template is fully filled out.
+
+
+    Thank you for using Stencil Sass!
+  close: true
+  lock: true
+  dryRun: false


### PR DESCRIPTION
this commit adds our internal bot 'ionitron' to the stencil-sass
repository. technically, ionitron is already configured for the repo,
but needs a configuration file (this commit) to run.

this commit adapts the ionitron configuration from stencil-store as of
https://github.com/ionic-team/stencil-store/commit/c2a75b2d350fcf2c59458ee777fa0064459c5c3a