### PR TITLE
chore(ci): run multiple versions of stencil

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,21 @@ on:
 
 jobs:
   build:
+    name: (build stencil ${{ matrix.stencil_version }})
+    strategy:
+      matrix:
+        # Run four different versions in parallel:
+        # 1. DEFAULT - uses the version of Stencil written in `package-lock.json`, keeping the same version used by the
+        # Stencil team as a source of truth
+        # 2. 2 - will install the latest release under major version 2 of Stencil. This should be kept as long as this
+        # library supports Stencil v2.Y.Z
+        # 3. v3-next - will install a pre-release version of Stencil v3, and is used to detect any regressions in a
+        # pre-release of v3.0.0.
+        # 4. latest - will install the latest version of Stencil. Prior to the Stencil v3.0.0 release, this will
+        # resolve to the latest version of Stencil v2. After the Stencil v3.0.0 release, it will resolve to the latest
+        # version of Stencil v3.
+        stencil_version: ['DEFAULT', '2', 'v3-next', 'latest']
+
     runs-on: ubuntu-latest
 
     steps:
@@ -27,6 +42,13 @@ jobs:
       shell: bash
     - name: Prettier Check
       run: npm run prettier.dry-run
+      shell: bash
+    - name: Install Stencil ${{matrix.stencil_version}}
+      run: npm install --save-dev @stencil/core@${{matrix.stencil_version}}
+      shell: bash
+      if: ${{ matrix.stencil_version != 'DEFAULT' }}
+    - name: Report Stencil Version
+      run: npm ls @stencil/core
       shell: bash
     - name: Build
       run: npm run build -- --ci


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

CI only runs on the version of Stencil that is declared in `package-lock.json`

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates our ci workflow to run the build and test steps against multiple versions of stencil. the motivating factors behind this change are as follows:
1. we're preparing to release stencil v3, and would like to catch any regresssions in the library prior to release
2. this library will simultanesouly support stencil v2 and v3 for a period of time, and would like to have ci run on both following the stencil v3.0.0 release

in pursuit of those goals, four versions of stencil are tested:
1. DEFAULT - uses the version of Stencil written in `package-lock.json`, keeping the same version used by the Stencil team as a source of truth
2. 2 - will install the latest release under major version 2 of Stencil. This should be kept as long as this library supports Stencil v2.Y.Z
3. v3-next - will install a pre-release version of Stencil v3, and is used to detect any regressions in a pre-release of v3.0.0.
4. latest - will install the latest version of Stencil. Prior to the Stencil v3.0.0 release, this will resolve to the latest version of Stencil v2. After the Stencil v3.0.0 release, it will resolve to the latest version of Stencil v3.

this allows the team to have full coverage with regards to testing now (prior to the stencil v3 release) where at the time of this writing:
1. DEFAULT - resolves to Stencil v2.21.0
2. 2 - resolves to Stencil v2.21.0
3. v3-next - resolves to Stencil v3.0.0-beta.1
4. latest - resolves to Stencil v2.21.0

following the stencil v3.0.0 release, the same versions will resolve as follows (without the team having to swoop in and change ci as a part of the v3 release process):
1. DEFAULT - resolves to Stencil v2.21.0 (and will require a code change post release, but not immediately due to other version tags)
2. 2 - resolves to the latest version of Stencil v2.Y.Z
3. v3-next - resolves to the last Stencil v3 pre-release (and can be removed at the team's leisure)
4. latest - will install the latest version of Stencil v3.Y.Z

this change will require code clean up (removing DEFAULT, v3-next). however, the value add here is that said change can happen any time following the stencil v3 release, and keeps the ci workflow resilient to unknown changes that may occur in the v2 and v3 branches of stencil core

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Tailed the results of this Action running, verifying that:
- For 'DEFAULT', no new version of Stencil is installed (the new install command is skipped)
- For other versions, the correct version of Stencil is installed (verifiable via the 'Report Stencil Version' step
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

If we land this as-is, I'll need to update the CI checks accordingly (it's still assuming a single 'build' check to run)