### PR TITLE
fix(utils): only run plugin for sass files

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -10,11 +10,11 @@ import { LegacyOptions } from 'sass/types/legacy/options';
  * @returns `true` if the name of the file ends with a sass extension (.scss, .sass), case insensitive. `false`
  * otherwise
  */
-export function usePlugin(fileName: string) {
+export function usePlugin(fileName: string): boolean {
   if (typeof fileName === 'string') {
     return /(\.scss|\.sass)$/i.test(fileName);
   }
-  return true;
+  return false;
 }
 
 /**

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -68,27 +68,20 @@ describe('getRenderOptions', () => {
 
 
 describe('usePlugin', () => {
-
-  it('should use the plugin for .scss file', () => {
-    const fileName = 'my-file.scss';
+  it.each(['.sass', '.scss', '.SASS', '.SCSS'])('returns true for a %s file', (extension) => {
+    const fileName = `my-file${extension}`;
     expect(util.usePlugin(fileName)).toBe(true);
   });
 
-  it('should use the plugin for .sass file', () => {
-    const fileName = 'my-file.sass';
-    expect(util.usePlugin(fileName)).toBe(true);
-  });
-
-  it('should not use the plugin for .pcss file', () => {
-    const fileName = 'my-file.pcss';
+  it.each(['.pcss', '.css', '.ts', '.tsx', '.js', '.jsx', '.mjs'])('returns false for a %s file', (extension) => {
+    const fileName = `my-file${extension}`;
     expect(util.usePlugin(fileName)).toBe(false);
   });
 
-  it('should not use the plugin for .css file', () => {
-    const fileName = 'my-file.css';
-    expect(util.usePlugin(fileName)).toBe(false);
+  it.each([undefined, null])('returns false for non-string file (%s)', (fileName) => {
+    // the intent of this test is to intentionally provide a non-string value, hence the assertion
+    expect(util.usePlugin(fileName as unknown as string)).toBe(false);
   });
-
 });
 
 describe('createResultsId', () => {


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

While I do not believe this occurs in practice, it is theoretically possible to try to run the plugin if a non-string filename is somehow provided to the plugin's `transform` function

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the utility method for checking whether the plugin should run on a file, `usePlugin` to return `false` for files that do not end in `.sass`/`.scss`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Updated unit tests.

The Ionic Framework never actually appears to hit the `return` statement I updated here, and should not be affected by this change
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
