### PR TITLE
chore(ci): don't fail fast for build job 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     name: (stencil-sass with Stencil version ${{ matrix.stencil_version }})
     strategy:
+      fail-fast: false
       matrix:
         # Run with multiple different versions of Stencil in parallel:
         # 1. DEFAULT - uses the version of Stencil written in `package-lock.json`, keeping the same version used by the

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -70,9 +70,6 @@ describe('getRenderOptions', () => {
 describe('usePlugin', () => {
 
   it('should use the plugin for .scss file', () => {
-    if (Math.random() > 0.5) {
-      throw new Error('RANDOM CHAOS!');
-    }
     const fileName = 'my-file.scss';
     expect(util.usePlugin(fileName)).toBe(true);
   });

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -70,6 +70,9 @@ describe('getRenderOptions', () => {
 describe('usePlugin', () => {
 
   it('should use the plugin for .scss file', () => {
+    if (Math.random() > 0.5) {
+      throw new Error('RANDOM CHAOS!');
+    }
     const fileName = 'my-file.scss';
     expect(util.usePlugin(fileName)).toBe(true);
   });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If one CI job fails, others may be cancelled without running to completion

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit prevents the build job from failing fast (i.e. if '2' in the
stencil_version matrix fails, the rest of the jobs will not fail). this
ought to allow us to root our stencil version-based errors more easily
if an error pertains to a single version

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

https://github.com/ionic-team/stencil-sass/pull/363/commits/ddeeb46836b344c738057403f3d9638d5973d1e3 was temporarily added to this branch to add a little bit of chaos/random error throwing. No jobs were cancelled as a result of errors being thrown
![Screenshot 2023-06-30 at 2 36 05 PM](https://github.com/ionic-team/stencil-sass/assets/1930213/d86f1b1d-506c-451f-8eb2-eb062db43403)

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
