### PR TITLE
fix(plugin): normalize dependency path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,11 @@ import { loadDiagnostic } from './diagnostics';
 import { createResultsId, getRenderOptions, usePlugin } from './util';
 
 /**
+ * Helper type to note which plugin methods are defined for this plugin.
+ */
+type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] }
+
+/**
  * The entrypoint of the Stencil Sass plugin
  *
  * This function creates & configures the plugin to be used by consuming Stencil projects
@@ -13,7 +18,7 @@ import { createResultsId, getRenderOptions, usePlugin } from './util';
  * @param opts options to configure the plugin
  * @return the configured plugin
  */
-export function sass(opts: d.PluginOptions = {}): d.Plugin {
+export function sass(opts: d.PluginOptions = {}): WithRequired<d.Plugin, 'transform'> {
   return {
     name: 'sass',
     pluginType: 'css',

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export function sass(opts: d.PluginOptions = {}): WithRequired<d.Plugin, 'transf
               results.code = `/**  sass error${err && err.message ? ': ' + err.message : ''}  **/`;
               resolve(results);
             } else {
-              results.dependencies = Array.from(sassResult.stats.includedFiles as string[]).map((dep) =>
+              results.dependencies = Array.from(sassResult.stats.includedFiles).map((dep) =>
                 context.sys.normalizePath(dep),
               );
               results.code = sassResult.css.toString();

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { createResultsId, getRenderOptions, usePlugin } from './util';
 /**
  * Helper type to note which plugin methods are defined for this plugin.
  */
-type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] }
+type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 
 /**
  * The entrypoint of the Stencil Sass plugin

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,9 @@ export function sass(opts: d.PluginOptions = {}): d.Plugin {
               results.code = `/**  sass error${err && err.message ? ': ' + err.message : ''}  **/`;
               resolve(results);
             } else {
-              results.dependencies = Array.from(sassResult.stats.includedFiles);
+              results.dependencies = Array.from(sassResult.stats.includedFiles as string[]).map((dep) =>
+                context.sys.normalizePath(dep),
+              );
               results.code = sassResult.css.toString();
 
               // write this css content to memory only so it can be referenced

--- a/test/build.spec.ts
+++ b/test/build.spec.ts
@@ -14,8 +14,10 @@ describe('test build', () => {
         rootDir: '/Users/my/app/',
         srcDir: '/Users/my/app/src/',
       },
-      cache: null,
-      sys: {} as any,
+      cache: null as any,
+      sys: {
+        normalizePath: jest.fn((p: string) => p),
+      } as any,
       fs: {
         readFileSync(filePath: string) {
           return fs.readFileSync(filePath, 'utf8');
@@ -50,6 +52,7 @@ describe('test build', () => {
       path.join(__dirname, 'fixtures', 'scss', 'variables.scss')
     ]);
     expect(results.diagnostics).toEqual(undefined);
+    expect(context.sys.normalizePath).toBeCalledTimes(1)
   });
 
   it('transform, error scss', async () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
Sass compiler dependencies aren't recognised given Windows path.

GitHub Issue Number: https://github.com/ionic-team/stencil/issues/4130


## What is the new behavior?
When changing dependent sass files, the compiler now correctly reloads the component with updated styles.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I used a virtual machine and updated the compiled code directly using the reproducible example provided in https://github.com/ionic-team/stencil/issues/4130. Any suggestions how I can provide something better given this bug is related to Windows.

## Other information

n/a
